### PR TITLE
Fix global particles not disabling in the Britney environment

### DIFF
--- a/HarmonyPatches/GlobalParticles.cs
+++ b/HarmonyPatches/GlobalParticles.cs
@@ -16,7 +16,7 @@ namespace Tweaks55.HarmonyPatches {
 		public static void SetEnabledState(bool enabled) {
 			if(!lastKnownState || !enabled) {
 				foreach(var x in Resources.FindObjectsOfTypeAll<ParticleSystem>())
-					if(x.name == "DustPS") x.gameObject.SetActive(enabled);
+					if(x.name == "DustPS" || x.name == "DustBritney") x.gameObject.SetActive(enabled);
 			}
 
 			lastKnownState = enabled;


### PR DESCRIPTION
Noticed the global dust particles in the Britney environment came back after dropping ParticleOverdrive and went to look what that was doing differently compared to Tweaks55. Turns out the particles there are named different from `DustPS` lol

https://github.com/ibillingsley/BeatSaber-ParticleOverdrive/commit/ee2be3c90fa443942268dfa39d46ae2d64164f56