### PR TITLE
Fix wall and bomb color overrides not working with Chroma

### DIFF
--- a/HarmonyPatches/ChromaColorizers.cs
+++ b/HarmonyPatches/ChromaColorizers.cs
@@ -10,7 +10,7 @@ namespace Tweaks55.HarmonyPatches {
 		[HarmonyPriority(int.MaxValue)]
 		[HarmonyPrefix]
 		static bool Prefix(ObstacleControllerBase obstactleController, Color? color) {
-			return !WallOutline.enabled;
+			return color.HasValue || !WallOutline.enabled;
 		}
 
 		static MethodBase TargetMethod() => Resolver.GetMethod("Chroma.Colorizer.ObstacleColorizerManager", "Colorize", assemblyName: "Chroma");
@@ -22,7 +22,7 @@ namespace Tweaks55.HarmonyPatches {
 		[HarmonyPriority(int.MaxValue)]
 		[HarmonyPrefix]
 		static bool Prefix(NoteControllerBase noteController, Color? color) {
-			return Config.Instance.bombColor == BombColor.defaultColor;
+			return color.HasValue || Config.Instance.bombColor == BombColor.defaultColor;
 		}
 
 		static MethodBase TargetMethod() => Resolver.GetMethod("Chroma.Colorizer.BombColorizerManager", "Colorize", assemblyName: "Chroma");

--- a/HarmonyPatches/ChromaColorizers.cs
+++ b/HarmonyPatches/ChromaColorizers.cs
@@ -1,0 +1,31 @@
+using HarmonyLib;
+using System;
+using System.Reflection;
+using Tweaks55.Util;
+using UnityEngine;
+
+namespace Tweaks55.HarmonyPatches {
+	[HarmonyPatch]
+	static class DisableObstacleColorizer {
+		[HarmonyPriority(int.MaxValue)]
+		[HarmonyPrefix]
+		static bool Prefix(ObstacleControllerBase obstactleController, Color? color) {
+			return !WallOutline.enabled;
+		}
+
+		static MethodBase TargetMethod() => Resolver.GetMethod("Chroma.Colorizer.ObstacleColorizerManager", "Colorize", assemblyName: "Chroma");
+		static Exception Cleanup(Exception ex) => Plugin.PatchFailed(ex);
+	}
+
+	[HarmonyPatch]
+	static class DisableBombColorizer {
+		[HarmonyPriority(int.MaxValue)]
+		[HarmonyPrefix]
+		static bool Prefix(NoteControllerBase noteController, Color? color) {
+			return Config.Instance.bombColor == BombColor.defaultColor;
+		}
+
+		static MethodBase TargetMethod() => Resolver.GetMethod("Chroma.Colorizer.BombColorizerManager", "Colorize", assemblyName: "Chroma");
+		static Exception Cleanup(Exception ex) => Plugin.PatchFailed(ex);
+	}
+}


### PR DESCRIPTION
Patches and skips the Chroma colorizer methods if the colors are already overwritten by Tweaks55